### PR TITLE
Define default timezone on application level (#30)

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -1,4 +1,5 @@
-from typing import Optional
+from datetime import timedelta, timezone
+from typing import Optional, Union
 
 from pydantic import BaseSettings
 
@@ -16,8 +17,19 @@ class Settings(BaseSettings):
     test_pg_port:  Optional[int] = 5432
     test_pg_db:  Optional[str]
 
+    timezone_offset: Union[str, int] = "utc"
+
     class Config:
         env_file = '.env'
+
+    @property
+    def timezone(self) -> timezone:
+        if self.timezone_offset == "utc":
+            return timezone.utc
+        if not isinstance(self.timezone_offset, int):
+            raise ValueError("Only 'utc' is an acceptable string representation for timezones")
+
+        return timezone(timedelta(hours=self.timezone_offset))
 
 
 settings = Settings()

--- a/backend/models.py
+++ b/backend/models.py
@@ -11,12 +11,15 @@ from sqlalchemy.orm.session import Session
 from sqlalchemy.ext.declarative import declared_attr
 from sqlalchemy.sql.schema import UniqueConstraint
 
+from .config import settings
 from .database import Base
+
 
 class Value(Base):
     __abstract__ = True
     
     id = Column(Integer, primary_key=True, index=True)
+
     @declared_attr
     def entity_id(cls):
         return Column(Integer, ForeignKey('entities.id'))
@@ -28,6 +31,7 @@ class Value(Base):
     @declared_attr
     def entity(cls):
         return relationship('Entity')
+
 
 class ValueBool(Value):
     __tablename__ = 'values_bool'
@@ -64,13 +68,19 @@ class Mapping(NamedTuple):
     converter: type
 
 
+def make_aware_datetime(dt: datetime) -> datetime:
+    if dt and dt.tzinfo is None:
+        return dt.replace(tzinfo=settings.timezone)
+    return dt
+
+
 class AttrType(enum.Enum):
     STR = Mapping(ValueStr, str)
     BOOL = Mapping(ValueBool, bool)
     INT = Mapping(ValueInt, int)
     FLOAT = Mapping(ValueFloat, float)
     FK = Mapping(ValueForeignKey, int)
-    DT = Mapping(ValueDatetime, lambda x: x)
+    DT = Mapping(ValueDatetime, make_aware_datetime)
 
 
 class BoundFK(Base):


### PR DESCRIPTION
Depending on the configuration of the Postgres database the default timezone might not be the
expected one.

This causes the unittests to fail and can cause unintended behavior in production.