### PR TITLE
Replaced response model for `general_routes.get_recent_*_changes`

### DIFF
--- a/backend/general_routes.py
+++ b/backend/general_routes.py
@@ -181,7 +181,7 @@ def review_changes(id: int, review: schemas.ChangeReviewSchema, db: Session = De
         raise HTTPException(status.HTTP_404_NOT_FOUND, str(e))
 
 
-@router.get('/changes/schema/{id_or_slug}', response_model=List[schemas.RecentChangeSchema])
+@router.get('/changes/schema/{id_or_slug}', response_model=List[schemas.ChangeRequestSchema])
 def get_recent_schema_changes(id_or_slug: Union[int, str], count: Optional[int] = Query(5), db: Session = Depends(get_db)):
     try:
         schema = crud.get_schema(db=db, id_or_slug=id_or_slug)
@@ -203,7 +203,7 @@ def get_schema_change_details(id_or_slug: Union[int, str], change_id: int, db: S
 
 @router.get(
     '/changes/entity/{schema_id_or_slug}/{entity_id_or_slug}',
-    response_model=List[schemas.RecentChangeSchema]
+    response_model=List[schemas.ChangeRequestSchema]
 )
 def get_recent_entity_changes(schema_id_or_slug: Union[int, str], entity_id_or_slug: Union[int, str], count: Optional[int] = Query(5), db: Session = Depends(get_db)):
     try:

--- a/backend/schemas/traceability.py
+++ b/backend/schemas/traceability.py
@@ -9,6 +9,7 @@ from .schema import AttrDefSchema, AttrDefUpdateSchema, SchemaBaseSchema
 
 
 class ChangeRequestSchema(BaseModel):
+    id: int
     created_at: datetime
     reviewed_at: Optional[datetime]
     created_by: str
@@ -52,15 +53,6 @@ class EntityChangeSchema(BaseModel):
 class EntityChangeDetailSchema(ChangeRequestSchema):
     entity: ChangedEntitySchema
     changes: dict[str, EntityChangeSchema]
-
-
-class RecentChangeSchema(BaseModel):
-    created_at: datetime
-    status: ChangeStatus
-    id: int
-
-    class Config:
-        orm_mode = True
 
 
 class SchemaChangesSchema(BaseModel):

--- a/backend/schemas/traceability.py
+++ b/backend/schemas/traceability.py
@@ -9,7 +9,7 @@ from .schema import AttrDefSchema, AttrDefUpdateSchema, SchemaBaseSchema
 
 
 class ChangeRequestSchema(BaseModel):
-    id: int
+    id: Optional[int]
     created_at: datetime
     reviewed_at: Optional[datetime]
     created_by: str


### PR DESCRIPTION
Replaced `RecentChangeSchema` with `ChangeRequestSchema`